### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 
 install:
   - pip install -e ".[test]"
+  - python -c "import nltk; nltk.download('cmudict')"
 
 script:
   - nosetests -v -w tests/ -a '!local_only'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
   - pip install -e ".[test]"
 
 script:
-  - nosetests -v -w -a '!local_only' tests/
+  - nosetests -v -w tests/ -a '!local_only'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+
+python:
+  - "3.6"
+
+notifications:
+  email: false
+
+before_install:
+  - sudo apt-get update
+  - if [["$TRAVIS_PYTHON_VERSION" == "2.7"]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda config --add channels pypi
+  - conda info -a
+  - deps='pip numpy scipy cython nose pytorch'
+  - conda create -q -n test-environment "python=$TRAVIS_PYTHON_VERSION" $deps -c pytorch
+  - source activate test-environment
+
+install:
+  - pip install -e ".[test]"
+
+script:
+  - nosetests -v -w -a '!local_only' tests/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python train.py --data-root=./data/ljspeech --checkpoint-dir=checkpoints_nyanko 
 - PyTorch >= v0.3
 - TensorFlow >= v1.3
 - [tensorboard-pytorch](https://github.com/lanpa/tensorboard-pytorch) (master)
-- [nnmnkwii](https://github.com/r9y9/nnmnkwii) >= v0.0.9
+- [nnmnkwii](https://github.com/r9y9/nnmnkwii) >= v0.0.11
 - [MeCab](http://taku910.github.io/mecab/) (Japanese only)
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(name='deepvoice3_pytorch',
           "librosa",
           "numba",
           "lws <= 1.0",
+          "nltk",
       ],
       extras_require={
           "train": [
@@ -66,7 +67,6 @@ setup(name='deepvoice3_pytorch',
               "tqdm",
               "tensorboardX",
               "nnmnkwii >= 0.0.11",
-              "nltk",
           ],
           "test": [
               "nose",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='deepvoice3_pytorch',
               "docopt",
               "tqdm",
               "tensorboardX",
-              "nnmnkwii >= 0.0.9",
+              "nnmnkwii >= 0.0.11",
               "nltk",
           ],
           "test": [

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -15,6 +15,7 @@ def test_en():
     assert t == "hello world.~"
 
 
+@attr("local_only")
 def test_ja():
     f = getattr(frontend, "jp")
     seq = f.text_to_sequence("こんにちわ")


### PR DESCRIPTION
Now that pytorch source build is not required, we can turn on travis CI.