### PR TITLE
Rollback to previous log compression

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -77,7 +77,8 @@ def _build_mel_basis():
 
 
 def _amp_to_db(x):
-    return 20 * np.log10(np.maximum(1e-5, x))
+    min_level = np.exp(hparams.min_level_db / 20 * np.log(10))
+    return 20 * np.log10(np.maximum(min_level, x))
 
 
 def _db_to_amp(x):

--- a/audio.py
+++ b/audio.py
@@ -77,11 +77,11 @@ def _build_mel_basis():
 
 
 def _amp_to_db(x):
-    return 20 * np.log10(x + 0.01)
+    return 20 * np.log10(np.maximum(1e-5, x))
 
 
 def _db_to_amp(x):
-    return np.maximum(np.power(10.0, x * 0.05) - 0.01, 0.0)
+    return np.power(10.0, x * 0.05)
 
 
 def _normalize(S):


### PR DESCRIPTION
I had misunderstood how log compression is done in Tactron2. The old
code already did clipping same way as mentioned in Tacotron2. Althrough
the threshold is different between ours (1e-5) and Tacotron2 (0.01),
I think it's safe to keep the value as is because it has been tested
for months. We can try 0.01 later.

should fix #43