### PR TITLE
Minor fix on Windows

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -15,7 +15,7 @@ import os
 from multiprocessing import cpu_count
 from tqdm import tqdm
 import importlib
-from hparams import hparams
+from hparams import hparams, hparams_debug_string
 
 
 def preprocess(mod, in_dir, out_root, num_workers):

--- a/synthesis.py
+++ b/synthesis.py
@@ -53,7 +53,7 @@ def tts(model, text, p=0, speaker_id=None, fast=False):
         model.make_generation_fast_()
 
     sequence = np.array(_frontend.text_to_sequence(text, p=p))
-    sequence = Variable(torch.from_numpy(sequence)).unsqueeze(0)
+    sequence = Variable(torch.from_numpy(sequence)).unsqueeze(0).long()
     text_positions = torch.arange(1, sequence.size(-1) + 1).unsqueeze(0).long()
     text_positions = Variable(text_positions)
     speaker_ids = None if speaker_id is None else Variable(torch.LongTensor([speaker_id]))


### PR DESCRIPTION
Hi
I have fixed the error,
`TypeError: torch.index_select received an invalid combination of arguments - got (torch.cuda.FloatTensor, int, torch.cuda.IntTensor), but expected (torch.cuda.FloatTensor source, int dim, torch.cuda.LongTensor index)`
on windows ,mentioned in the issue #37
Please consider it for merging. Thank you.