### PR TITLE
Typo in variable name: input_lenghts --> input_lengths

### DIFF
--- a/tests/test_deepvoice3.py
+++ b/tests/test_deepvoice3.py
@@ -255,7 +255,7 @@ def test_incremental_forward():
         max_input_len = np.max(input_lengths) + 10  # manuall padding
         seqs = np.array([_pad(x, max_input_len) for x in seqs], dtype=np.int)
         input_lengths = torch.LongTensor(input_lengths)
-        input_lengths = input_lengths.cuda() if use_cuda else input_lenghts
+        input_lengths = input_lengths.cuda() if use_cuda else input_lengths
     else:
         input_lengths = None
 


### PR DESCRIPTION
Discovered via: [__flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__](https://travis-ci.org/r9y9/deepvoice3_pytorch/builds/371514640#L762-L779)