### PR TITLE
windows: Enable AppVeyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ build_script:
   - python -c "import nltk; nltk.download('cmudict')"
 
 test_script:
-  - nosetests -v tests/test_audio.py tests/test_conv.py tests/test_deepvoice3.py tests/test_embedding.py tests/test_frontend.py tests/test_nyanko.py -a '!local_only'
+  - nosetests -v -w tests/ -a "!local_only"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+  matrix:
+    - PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda36-x64
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+skip_commits:
+  message: /\[av skip\]/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+init:
+  - "ECHO %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes  --set changeps1 no
+  - conda update -q conda
+  - conda install -n root _license
+  - conda info -a
+  - "conda create -q -n test-environment python=%PYTHON_VERSION% numpy scipy cython nose pytorch -c pytorch"
+  - activate test-environment
+
+build_script:
+  - pip install -e ".[test]"
+  - python -c "import nltk; nltk.download('cmudict')"
+
+test_script:
+  - nosetests -v -w tests/ -a '!local_only'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ build_script:
   - python -c "import nltk; nltk.download('cmudict')"
 
 test_script:
-  - nosetests -v -w tests/ -a '!local_only'
+  - nosetests -v tests/test_audio.py tests/test_conv.py tests/test_deepvoice3.py tests/test_embedding.py tests/test_frontend.py tests/test_nyanko.py -a '!local_only'


### PR DESCRIPTION
Now that pytorch has windows support, we can enable AppVeyor testing. appveyor.yml was copied from my other project.