### PR TITLE
Remove hard-coded switching backend of matplotlib and pyqt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,19 @@ There are two important options used above:
 
 If you are training multi-speaker model, speaker adaptation will only work **when `n_speakers` is identical**.
 
+## Trouble shooting
+
+### [#5](https://github.com/r9y9/deepvoice3_pytorch/issues/5) RuntimeError: main thread is not in main loop
+
+
+This may happen depending on backends you have for matplotlib. Try changing backend for matplotlib and see if it works as follows:
+
+```
+MPLBACKEND=Qt5Agg python train.py ${args...}
+```
+
+In [#78](https://github.com/r9y9/deepvoice3_pytorch/pull/78#issuecomment-385327057), engiecat reported that changing the backend of matplotlib from Tkinter(TkAgg) to PyQt5(Qt5Agg) fixed the problem.
+
 ## Acknowledgements
 
 Part of code was adapted from the following projects:

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(name='deepvoice3_pytorch',
               "tensorboardX",
               "nnmnkwii >= 0.0.11",
               "requests",
-              "PyQt5",
           ],
           "test": [
               "nose",

--- a/train.py
+++ b/train.py
@@ -57,9 +57,6 @@ from hparams import hparams, hparams_debug_string
 
 fs = hparams.sample_rate
 
-# Prevent Issue #5
-plt.switch_backend('Qt5Agg')
-
 global_step = 0
 global_epoch = 0
 use_cuda = torch.cuda.is_available()


### PR DESCRIPTION
and add trouble shooting section to README.

On Google Colab, it turned out PyQt backend is problematic. I think switching backend by environmental variable is flexible and better than hard coded. cc: @engiecat 

https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend

ref: https://github.com/r9y9/deepvoice3_pytorch/pull/78#issuecomment-385327057