### PR TITLE
Fixes #108 until tensorboardX deals with the writer.add_image() problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(name='deepvoice3_pytorch',
           "bin": [
               "docopt",
               "tqdm",
-              "tensorboardX",
+              "tensorboardX <= 1.2",
               "nnmnkwii >= 0.0.11",
               "requests",
           ],


### PR DESCRIPTION
An error appears while training if a recent tensorboardX version is installed.
This is described in #108.
While an upstream solution is prepared, limiting tensorboardX version seems reasonable.