### PR TITLE
adding nltk.download('popular') 

### DIFF
--- a/synthesis.py
+++ b/synthesis.py
@@ -33,6 +33,7 @@ from deepvoice3_pytorch import frontend
 from hparams import hparams, hparams_debug_string
 
 from tqdm import tqdm
+nltk.download('popular')
 
 use_cuda = torch.cuda.is_available()
 device = torch.device("cuda" if use_cuda else "cpu")


### PR DESCRIPTION
the package adds all popular nltk packages so that code does not error out when it does not find cmudict or the punkt package.