### PR TITLE
Fix mel function parameters errors

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -71,7 +71,7 @@ def _linear_to_mel(spectrogram):
 def _build_mel_basis():
     if hparams.fmax is not None:
         assert hparams.fmax <= hparams.sample_rate // 2
-    return librosa.filters.mel(hparams.sample_rate, hparams.fft_size,
+    return librosa.filters.mel(sr=hparams.sample_rate, n_fft=hparams.fft_size,
                                fmin=hparams.fmin, fmax=hparams.fmax,
                                n_mels=hparams.num_mels)
 


### PR DESCRIPTION
The recent version of the mel() function takes 0 positional arguments. We use keywords arguments to quick fix 'mel() takes 0 positional arguments'  error